### PR TITLE
Update BatchChildEditor.module

### DIFF
--- a/BatchChildEditor.module
+++ b/BatchChildEditor.module
@@ -1370,7 +1370,7 @@ function buildCoreSettings ($data, $wrapper, $pid = null) {
     $f->label = __('Update mode notes');
     $f->showIf = "editModes=update";
     $f->columnWidth = 33;
-    $f->description = __('Custom text for notes in Add mode.');
+    $f->description = __('Custom text for notes in Update mode.');
     $f->value = $pid && isset($data['pageSettings'][$pid]) ? $data['pageSettings'][$pid]['updateModeNotes'] : $data['updateModeNotes'];
     $fieldset->add($f);
 
@@ -1397,7 +1397,7 @@ function buildCoreSettings ($data, $wrapper, $pid = null) {
     $f->label = __('Replace mode notes');
     $f->showIf = "editModes=replace";
     $f->columnWidth = 33;
-    $f->description = __('Custom text for notes in Add mode.');
+    $f->description = __('Custom text for notes in Replace mode.');
     $f->value = $pid && isset($data['pageSettings'][$pid]) ? $data['pageSettings'][$pid]['replaceModeNotes'] : $data['replaceModeNotes'];
     $fieldset->add($f);
 }


### PR DESCRIPTION
Some textstrings are not translatable since there where the same (via copy&paste from other inputfields).
